### PR TITLE
Fix output for multiline strings

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,4 +8,4 @@ echo "redocly version: $(redocly --version)"
 
 output=$(redocly $1)
 
-echo "{output}={$output}" >> $GITHUB_OUTPUT
+echo "output<<$EOF $output $EOF" >> $GITHUB_OUTPUT

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,4 +8,6 @@ echo "redocly version: $(redocly --version)"
 
 output=$(redocly $1)
 
-echo "output<<$EOF $output $EOF" >> $GITHUB_OUTPUT
+echo "output<<$EOF" >> $GITHUB_OUTPUT
+echo "$output" >> $GITHUB_OUTPUT
+echo "$EOF" >> $GITHUB_OUTPUT

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,4 @@ echo "redocly version: $(redocly --version)"
 
 output=$(redocly $1)
 
-echo "output<<$EOF" >> $GITHUB_OUTPUT
-echo "$output" >> $GITHUB_OUTPUT
-echo "$EOF" >> $GITHUB_OUTPUT
+echo "output<<EOF"$'\n'"$output"$'\n'EOF >> $GITHUB_OUTPUT


### PR DESCRIPTION
You made some changes to the output since the previous method is getting deprecated. But this does not work for multiline strings and throws a error like this:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 
```
This is a fix for that

see https://stackoverflow.com/questions/74137120/how-to-fix-or-avoid-error-unable-to-process-file-command-output-successfully 